### PR TITLE
Do not wait for the sound to finish

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ Example Use
 
    import beepy
    beep(sound=1) # integer as argument
+   beep(sound=1, wait=False) # string as argument, do not wait for the sound to finish
    beep(sound='coin') # string as argument
+   beep(sound='coin',wait=False) # string as argument, do not wait for the sound to finish
 
 Requirements
 =============
@@ -42,6 +44,8 @@ Following are the mappings for the numbers:
 ``5`` : ``'ready'``\ ,
 ``6`` : ``'success'``\ ,
 ``7`` : ``'wilhelm'``
+
+``wait`` is a boolean that just defines if the program should wait for the sound to finish
 
 
 Issues

--- a/beepy/make_sound.py
+++ b/beepy/make_sound.py
@@ -15,7 +15,7 @@ wave_dict = {
             7:'wilhelm.wav'
             }
 
-def beep(sound=1):
+def beep(sound=1,wait: bool=True):
     sound_names = [
                    "coin",
                    'robot_error',
@@ -40,4 +40,4 @@ def beep(sound=1):
 
     wave_obj = sa.WaveObject.from_wave_file(WAVE_PATH)
     play_obj = wave_obj.play()
-    play_obj.wait_done()
+    if wait: play_obj.wait_done()


### PR DESCRIPTION
Some users might want to just mark some segments as complete, and stopping for audio may consume some time. This patch adds an `wait` argument so these users can set it to `False` and the program will continue with audio in the background.